### PR TITLE
Rename refactoring for type, function and union types.

### DIFF
--- a/Data Structures/BinaryTree.fs
+++ b/Data Structures/BinaryTree.fs
@@ -1,13 +1,13 @@
 ﻿module BinaryTree
 
-type Tree<'a when 'a:comparison> = 
-    | TreeElement of 'a
-    | BinaryTree of Tree<'a> * 'a * Tree<'a>
+type BinaryTree<'a when 'a:comparison> = 
+    | Element of 'a
+    | Tree of BinaryTree<'a> * 'a * BinaryTree<'a>
 
-let rec treeMember (element :'a) (tree :Tree<'a>) =
+let rec isMember (element :'a) (tree :BinaryTree<'a>) =
     match tree with 
-    | TreeElement a -> a = element
-    | BinaryTree (left, top, right) -> 
-        if top < element then treeMember element right
-        else if top > element then treeMember element left
+    | Element a -> a = element
+    | Tree (left, top, right) -> 
+        if top < element then isMember element right
+        else if top > element then isMember element left
         else true

--- a/DataStructure.Tests/BinaryTreeTest.fs
+++ b/DataStructure.Tests/BinaryTreeTest.fs
@@ -4,21 +4,21 @@ open BinaryTree
 open NUnit.Framework
 open Swensen.Unquote
 
-let singleNode = TreeElement 4
-let simpleTree = BinaryTree (TreeElement 4, 6, TreeElement 7)
+let singleNode = Element 4
+let simpleTree = Tree (Element 4, 6, Element 7)
 
 [<Test>]
-let ``treeMember given element 4 and singleNode 4 returns true`` () =
-    treeMember 4 singleNode =! true
+let ``isMember given element 4 and singleNode 4 returns true`` () =
+    isMember 4 singleNode =! true
 
 [<Test>]
-let ``treeMember given element 8 and simpleTree (does not contain 8) returns false`` () =
-    treeMember 8 simpleTree =! false
+let ``isMember given element 8 and simpleTree (does not contain 8) returns false`` () =
+    isMember 8 simpleTree =! false
 
 [<Test>]
-let ``treeMember given element 4 and simpleTree (4 is in left branch) returns true`` () =
-    treeMember 4 simpleTree =! true
+let ``isMember given element 4 and simpleTree (4 is in left branch) returns true`` () =
+    isMember 4 simpleTree =! true
 
 [<Test>]
-let ``treeMember given element 6 and simpleTree (6 is at the top) returns true`` () =
-    treeMember 6 simpleTree =! true
+let ``isMember given element 6 and simpleTree (6 is at the top) returns true`` () =
+    isMember 6 simpleTree =! true


### PR DESCRIPTION
The type is BinaryTree, elements of the tree can be either Tree or Element. 
Function treeMember renamed to isMember to follow is/has prefix for functions that results in bool.